### PR TITLE
Fix browserify transform argument order

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -46,10 +46,10 @@ function browserifyTask(watch) {
     }
 
     //iterate through every transform in config and load them
-    for(var transform in config.browserify.transforms) {
+    for (var transform in config.browserify.transforms) {
         if (config.browserify.transforms.hasOwnProperty(transform)) {
             var options = config.browserify.transforms[transform];
-            b.transform(options, require(transform));
+            b.transform(require(transform), options);
         }
     }
 


### PR DESCRIPTION
## Summary
- fix browserify transform call to pass transform module before options

## Testing
- `npm test` *(fails: sh: 1: gulp: not found)*
- `npm install` *(fails: connect to host github.com port 22: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68979461f97c832f9bbb01a335e0d4fb